### PR TITLE
Fix feature flag to not mandatory require libudev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ tokio-io = "0.1"
 tokio-reactor = "0.1"
 bytes = "0.4"
 mio = "0.6"
-mio-serial = "=3.1"
+mio-serial = { version = "=3.1", default-features = false }
 
 [dev-dependencies]
 tokio = "0.1"


### PR DESCRIPTION
Before, the mio-serial/default feature wasn't turned off even if the default
feature of the tokio-serial was off. We need to deselect the mio-serial/default
explicitly, and turn it on by the default of the tokio-serial.