### PR TITLE
Minor improvements to 5.4.0-beta1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,10 +48,6 @@ version = "1.8.1"
 features = ["macros"]
 default-features = false
 
-[target.'cfg(windows)'.dependencies]
-serialport = { version = "4", default-features = false }
-winapi = { version = "0.3", features = ["commapi", "fileapi", "handleapi", "winbase", "winnt"] }
-
 
 [[example]]
 name = "serial_println"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -510,17 +510,17 @@ mod io {
 ///
 /// This trait adds one method to SerialPortBuilder:
 ///
-/// - open_async
+/// - open_native_async
 ///
-/// These methods mirror the `open` and `open_native` methods of SerialPortBuilder
+/// This method mirrors the `open_native` method of SerialPortBuilder
 pub trait SerialPortBuilderExt {
     /// Open a platform-specific interface to the port with the specified settings
-    fn open_async(self) -> Result<SerialStream>;
+    fn open_native_async(self) -> Result<SerialStream>;
 }
 
 impl SerialPortBuilderExt for SerialPortBuilder {
     /// Open a platform-specific interface to the port with the specified settings
-    fn open_async(self) -> Result<SerialStream> {
+    fn open_native_async(self) -> Result<SerialStream> {
         SerialStream::open(&self)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,11 @@ pub type Result<T> = mio_serial::Result<T>;
 pub struct SerialStream {
     #[cfg(unix)]
     inner: AsyncFd<mio_serial::SerialStream>,
+    // Named pipes and COM ports are actually two entirely different things that hardly have anything in common.
+    // The only thing they share is the opaque `HANDLE` type that can be fed into `CreateFileW`, `ReadFile`, `WriteFile`, etc.
+    //
+    // Both `mio` and `tokio` don't yet have any code to work on arbitrary HANDLEs.
+    // But they have code for dealing with named pipes, and we (ab)use that here to work on COM ports.
     #[cfg(windows)]
     inner: named_pipe::NamedPipeClient,
     // The com port is kept around for serialport related methods

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -500,24 +500,19 @@ mod io {
         }
     }
 }
-//
-//
-//
+
 /// An extension trait for serialport::SerialPortBuilder
 ///
-/// This trait adds two methods to SerialPortBuilder:
+/// This trait adds one method to SerialPortBuilder:
 ///
 /// - open_async
-/// - open_native_async
 ///
 /// These methods mirror the `open` and `open_native` methods of SerialPortBuilder
 pub trait SerialPortBuilderExt {
-    // /// Open a cross-platform interface to the port with the specified settings
-    // fn open_async(self) -> Result<Box<dyn MioSerialPort>>;
-
     /// Open a platform-specific interface to the port with the specified settings
     fn open_async(self) -> Result<SerialStream>;
 }
+
 impl SerialPortBuilderExt for SerialPortBuilder {
     /// Open a platform-specific interface to the port with the specified settings
     fn open_async(self) -> Result<SerialStream> {


### PR DESCRIPTION
Removes no longer required dependencies and fix some comments.

Apart from that, 5.4.0-beta1 looks fine to me. Did you really want to release that as *5.4.0* though and not *4.4.0* or *5.0*?
I guess, you could still yank the 5.4.0-beta1 release from crates.io and change the version number if required.