### PR TITLE
Fix building the example after the rename to `open_native_async`

### DIFF
--- a/examples/serial_println.rs
+++ b/examples/serial_println.rs
@@ -44,7 +44,7 @@ async fn main() -> tokio_serial::Result<()> {
     let mut args = env::args();
     let tty_path = args.nth(1).unwrap_or_else(|| DEFAULT_TTY.into());
 
-    let mut port = tokio_serial::new(tty_path, 9600).open_async()?;
+    let mut port = tokio_serial::new(tty_path, 9600).open_native_async()?;
 
     #[cfg(unix)]
     port.set_exclusive(false)


### PR DESCRIPTION
@berkowski 