### PR TITLE
Re-export `SerialPortType` and `UsbPortInfo` from `mio-serial`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 // Re-export serialport types and traits from mio_serial
 pub use mio_serial::{
     available_ports, new, ClearBuffer, DataBits, Error, ErrorKind, FlowControl, Parity, SerialPort,
-    SerialPortBuilder, SerialPortInfo, StopBits,
+    SerialPortBuilder, SerialPortInfo, SerialPortType, StopBits, UsbPortInfo,
 };
 
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};


### PR DESCRIPTION
This PR re-exports some types to allow the user to use the `port_type` field of `SerialPortInfo`. However it can be merged only once [berkowski/mio_serial#28](https://github.com/berkowski/mio-serial/pull/28) has been merged 