### PR TITLE
Fix regression by updating Cargo.toml to depend on mio-serial 5.0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ default-features = false
 optional = true
 
 [dependencies.mio-serial]
-version = "5"
+version = "5.0.2"
 default-features = false
 
 [dependencies.bytes]


### PR DESCRIPTION
This fixes ff8d9ecddf0151f3a72b7fe9afcab0e112f50dcb, which introduces a
dependency on mio-serial 5.0.2 but did not bump the version requirement
in `Cargo.toml`. Without also updating `Cargo.toml` to depend on mio-serial
5.0.2, upgrading a project with an old lock file to latest tokio-serial will break with 

```
error[E0432]: unresolved imports `mio_serial::SerialPortType`, `mio_serial::UsbPortInfo`
  --> /builds/straw/proj/.cargo-proj/registry/src/github.com-1ecc6299db9ec823/tokio-serial-5.4.2/src/lib.rs:13:40
   |
13 |     SerialPortBuilder, SerialPortInfo, SerialPortType, StopBits, UsbPortInfo,
   |                                        ^^^^^^^^^^^^^^            ^^^^^^^^^^^ no `UsbPortInfo` in the root
   |                                        |
   |                                        no `SerialPortType` in the root
   |                                        help: a similar name exists in the module: `SerialPort`
```
