### PR TITLE
Update the default tty on unix

### DIFF
--- a/tests/test_serialstream.rs
+++ b/tests/test_serialstream.rs
@@ -6,7 +6,12 @@ use tokio::{
 use tokio_serial::SerialPortBuilderExt;
 
 #[cfg(unix)]
-const DEFAULT_TEST_PORT_NAMES: &str = "/dev/ttyUSB0;/dev/ttyUSB1";
+const DEFAULT_TEST_PORT_NAMES: &str = concat!(
+    env!("CARGO_TARGET_TMPDIR"),
+    "/ttyUSB0;",
+    env!("CARGO_TARGET_TMPDIR"),
+    "/ttyUSB1"
+);
 #[cfg(not(unix))]
 const DEFAULT_TEST_PORT_NAMES: &str = "COM10;COM11";
 


### PR DESCRIPTION
Running `cargo test` on a stock Fedora 36 gives a permission error. This
update creates the default test port names in the CARGO_TARGET_TMPDIR
where the developer should have permission and doesn't risk colliding
with an existing device node.