### PR TITLE
Add docs.rs metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ edition = "2018"
 [package.metadata]
 msrv = "1.46.0"
 
+[package.metadata.docs.rs]
+features = ["codec"]
+
 [features]
 default = []
 libudev = ["mio-serial/libudev"]


### PR DESCRIPTION
This enables the `codec` feature just for docs.rs so that `SerialFramed` is also documented.