### PR TITLE
Allow constructing a SerialStream from a TTYPort

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,10 @@ version = "0.4"
 [dependencies.cfg-if]
 version = "1"
 
+[dependencies.serialport]
+version = "4"
+default-features = false
+
 [dev-dependencies.tokio]
 version = "^1.8"
 features = ["macros", "rt", "process", "time", "fs", "io-util"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub use mio_serial::{
 
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
+use std::convert::TryFrom;
 use std::io::{Read, Result as IoResult, Write};
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -485,6 +486,18 @@ impl Write for SerialStream {
 
     fn flush(&mut self) -> IoResult<()> {
         self.borrow_mut().flush()
+    }
+}
+
+#[cfg(unix)]
+impl TryFrom<serialport::TTYPort> for SerialStream {
+    type Error = Error;
+
+    fn try_from(value: serialport::TTYPort) -> std::result::Result<Self, Self::Error> {
+        let port = mio_serial::SerialStream::try_from(value)?;
+        Ok(Self {
+            inner: AsyncFd::new(port)?,
+        })
     }
 }
 


### PR DESCRIPTION
There was already an implementation in mio_serial that allowed fallible conversions from a TTYPort, this just exposes that in tokio-serial.

I have a use case where I can't use the builder from `serialport`, so I construct a TTYPort from a raw file descriptor. After that, there is no way to make a SerialStream as far as I can tell. Regardless, this API seems pretty sane so I figured I'd make a PR.