### PR TITLE
(fix): made framed module public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ use std::task::{Context, Poll};
 use std::time::Duration;
 
 #[cfg(feature = "codec")]
-mod frame;
+pub mod frame;
 
 #[cfg(unix)]
 mod os_prelude {


### PR DESCRIPTION
See issue: https://github.com/berkowski/tokio-serial/issues/61
The framed module is both private and hidden behind a feature flag, meaning that library consumers can't create SerialFramed.
The module being gated by a feature flag seems to suggest that the module is supposed to be public.

This PR fixes this by making the module public.




