### PR TITLE
Replace `futures` with `futures-core` + `futures-sink`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,10 @@ libudev = ["mio-serial/libudev"]
 rt = ["tokio/rt-multi-thread"]
 codec = ["tokio-util/codec", "bytes"]
 
-[dependencies.futures]
+[dependencies.futures-core]
+version = "0.3"
+
+[dependencies.futures-sink]
 version = "0.3"
 
 [dependencies.tokio]
@@ -69,6 +72,10 @@ default-features = false
 
 [dev-dependencies]
 anyhow = "1.0.91"
+
+[dev-dependencies.futures-util]
+version = "0.3"
+default-features = false
 
 [dev-dependencies.tokio]
 version = "^1.8"

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -4,13 +4,13 @@ use super::SerialStream;
 
 use tokio_util::codec::{Decoder, Encoder};
 
-use futures::{Sink, Stream};
+use futures_core::Stream;
+use futures_sink::Sink;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 use bytes::{BufMut, BytesMut};
-use futures::ready;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 use std::{io, mem::MaybeUninit};
 
 /// A unified [`Stream`] and [`Sink`] interface to an underlying `SerialStream`, using

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub mod frame;
 
 #[cfg(unix)]
 mod os_prelude {
-    pub use futures::ready;
+    pub use std::task::ready;
     pub use tokio::io::unix::AsyncFd;
 }
 


### PR DESCRIPTION
`futures` is a heavy dependency, and this crate uses none of their own APIs. This drops it in favor of the smaller underlying dependencies.

Closes #73